### PR TITLE
Improve PHP portal

### DIFF
--- a/application.php
+++ b/application.php
@@ -1,5 +1,10 @@
-<?php require 'config.php'; require 'header.php';
-if ($_SERVER["REQUEST_METHOD"] == "POST") {
+<?php
+require 'config.php';
+require 'header.php';
+
+$msg = '';
+$selected = isset($_GET['course']) ? (int)$_GET['course'] : 0;
+if ($_SERVER["REQUEST_METHOD"] === "POST") {
     $course_id = $_POST['course_id'];
     $start_date = $_POST['start_date'];
     $payment_method = $_POST['payment_method'];
@@ -8,20 +13,21 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $stmt->bind_param("iiss", $_SESSION['user_id'], $course_id, $start_date, $payment_method);
 
     if ($stmt->execute()) {
-        echo "<div class='alert alert-success'>Заявка успешно отправлена.</div>";
+        $msg = "<div class='alert alert-success'>Заявка успешно отправлена.</div>";
     } else {
-        echo "<div class='alert alert-danger'>Ошибка: {$stmt->error}</div>";
+        $msg = "<div class='alert alert-danger'>Ошибка: {$stmt->error}</div>";
     }
 }
 
 $courses = $mysqli->query("SELECT * FROM courses");
 ?>
+<?= $msg ?>
 <form method="POST" class="card p-4 mb-4">
     <h2 class="mb-3">Новая заявка</h2>
     <div class="mb-3"><label class="form-label">Курс</label>
     <select name="course_id" class="form-select">
     <?php while ($c = $courses->fetch_assoc()): ?>
-        <option value="<?= $c['id'] ?>"><?= $c['name'] ?></option>
+        <option value="<?= $c['id'] ?>" <?= $selected == $c['id'] ? 'selected' : '' ?>><?= $c['name'] ?></option>
     <?php endwhile; ?>
     </select>
     </div>

--- a/courses.php
+++ b/courses.php
@@ -1,0 +1,22 @@
+<?php
+require 'config.php';
+require 'header.php';
+
+$courses = $mysqli->query("SELECT * FROM courses");
+?>
+<h2 class="mb-4">Список курсов</h2>
+<div class="row">
+<?php while ($c = $courses->fetch_assoc()): ?>
+  <div class="col-md-4 mb-4">
+    <div class="card h-100">
+      <img src="<?= $c['image_url'] ?>" class="card-img-top" alt="Курс">
+      <div class="card-body d-flex flex-column">
+        <h5 class="card-title"><?= $c['name'] ?></h5>
+        <p class="card-text mb-4"><?= $c['description'] ?></p>
+        <a href="application.php?course=<?= $c['id'] ?>" class="btn btn-primary mt-auto">Оформить заявку</a>
+      </div>
+    </div>
+  </div>
+<?php endwhile; ?>
+</div>
+<?php require 'footer.php'; ?>

--- a/header.php
+++ b/header.php
@@ -1,4 +1,3 @@
-
 <?php
 session_start();
 if (!isset($_SESSION['user_id']) && basename($_SERVER['PHP_SELF']) != 'login.php' && basename($_SERVER['PHP_SELF']) != 'register.php') {
@@ -45,7 +44,11 @@ if (!isset($_SESSION['user_id']) && basename($_SERVER['PHP_SELF']) != 'login.php
       <ul class="navbar-nav ms-auto">
         <?php if (isset($_SESSION['user_id'])): ?>
         <li class="nav-item"><a class="nav-link" href="dashboard.php">Главная</a></li>
+        <li class="nav-item"><a class="nav-link" href="courses.php">Курсы</a></li>
         <li class="nav-item"><a class="nav-link" href="application.php">Подать заявку</a></li>
+        <?php if (!empty($_SESSION['is_admin'])): ?>
+        <li class="nav-item"><a class="nav-link" href="admin.php">Админ</a></li>
+        <?php endif; ?>
         <li class="nav-item"><a class="nav-link" href="logout.php">Выйти</a></li>
         <?php endif; ?>
       </ul>

--- a/login.php
+++ b/login.php
@@ -1,5 +1,9 @@
-<?php session_start(); require 'config.php'; require 'header.php';
-if ($_SERVER["REQUEST_METHOD"] == "POST") {
+<?php
+session_start();
+require 'config.php';
+
+$msg = '';
+if ($_SERVER["REQUEST_METHOD"] === "POST") {
     $login = $_POST['login'];
     $password = $_POST['password'];
 
@@ -12,16 +16,16 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     if ($user_id && password_verify($password, $hash)) {
         $_SESSION['user_id'] = $user_id;
         $_SESSION['is_admin'] = $is_admin;
-        if ($is_admin) {
-            header("Location: admin.php");
-        } else {
-            header("Location: dashboard.php");
-        }
+        $target = $is_admin ? 'admin.php' : 'dashboard.php';
+        header("Location: $target");
+        exit();
     } else {
-        echo "<div class='alert alert-danger'>Неверный логин или пароль.</div>";
+        $msg = "<div class='alert alert-danger'>Неверный логин или пароль.</div>";
     }
 }
 ?>
+<?php require 'header.php'; ?>
+<?= $msg ?>
 <form method="POST" class="card p-4">
     <h2 class="mb-3">Вход</h2>
     <div class="mb-3"><label class="form-label">Логин</label><input type="text" name="login" class="form-control" required></div>

--- a/logout.php
+++ b/logout.php
@@ -1,1 +1,2 @@
 <?php session_start(); session_destroy(); header("Location: login.php"); ?>
+

--- a/register.php
+++ b/register.php
@@ -1,5 +1,8 @@
-<?php require 'config.php'; require 'header.php';
-if ($_SERVER["REQUEST_METHOD"] == "POST") {
+<?php
+require 'config.php';
+
+$msg = '';
+if ($_SERVER["REQUEST_METHOD"] === "POST") {
     $fio = $_POST['fio'];
     $phone = $_POST['phone'];
     $email = $_POST['email'];
@@ -7,19 +10,30 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $password = password_hash($_POST['password'], PASSWORD_DEFAULT);
 
     if (mb_strlen($login) < 6 || mb_strlen($_POST['password']) < 6) {
-        echo "<div class='alert alert-danger'>Логин и пароль должны быть не менее 6 символов.</div>";
+        $msg = "<div class='alert alert-danger'>Логин и пароль должны быть не менее 6 символов.</div>";
     } else {
-        $stmt = $mysqli->prepare("INSERT INTO users (fio, phone, email, login, password) VALUES (?, ?, ?, ?, ?)");
-        $stmt->bind_param("sssss", $fio, $phone, $email, $login, $password);
+        $check = $mysqli->prepare("SELECT id FROM users WHERE login = ?");
+        $check->bind_param("s", $login);
+        $check->execute();
+        $check->store_result();
 
-        if ($stmt->execute()) {
-            echo "<div class='alert alert-success'>Регистрация успешна. <a href='login.php'>Войти</a></div>";
+        if ($check->num_rows > 0) {
+            $msg = "<div class='alert alert-danger'>Логин уже существует.</div>";
         } else {
-            echo "<div class='alert alert-danger'>Ошибка: {$stmt->error}</div>";
+            $stmt = $mysqli->prepare("INSERT INTO users (fio, phone, email, login, password) VALUES (?, ?, ?, ?, ?)");
+            $stmt->bind_param("sssss", $fio, $phone, $email, $login, $password);
+
+            if ($stmt->execute()) {
+                $msg = "<div class='alert alert-success'>Регистрация успешна. <a href='login.php'>Войти</a></div>";
+            } else {
+                $msg = "<div class='alert alert-danger'>Ошибка: {$stmt->error}</div>";
+            }
         }
     }
 }
 ?>
+<?php require 'header.php'; ?>
+<?= $msg ?>
 <form method="POST" class="card p-4">
     <h2 class="mb-3">Регистрация</h2>
     <div class="mb-3"><label class="form-label">ФИО</label><input type="text" name="fio" class="form-control" required></div>


### PR DESCRIPTION
## Summary
- fix session redirect issues
- show admin/courses links in header
- tweak login/registration/app forms
- add course list page

## Testing
- `php -l header.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68546b136bc08333b9c65edb0e240e01

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing user session management, course listing, application submission, and user registration with improved feedback messages, structure, and navigation links.

### Detailed summary
- Added `logout.php` for session termination and redirection.
- Introduced course listing in `courses.php`.
- Updated `header.php` to include a link to `courses.php` and admin access for admins.
- Improved feedback messages in `login.php`, `application.php`, and `register.php`.
- Enhanced form handling in `login.php`, `application.php`, and `register.php` for better user experience.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->