### PR TITLE
Fix sessions and remove password hashing

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -1,5 +1,7 @@
 <?php
-session_start();
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
 require 'config.php';
 
 if (!isset($_SESSION['user_id']) || $_SESSION['is_admin'] != 1) {

--- a/header.php
+++ b/header.php
@@ -1,5 +1,7 @@
 <?php
-session_start();
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
 if (!isset($_SESSION['user_id']) && basename($_SERVER['PHP_SELF']) != 'login.php' && basename($_SERVER['PHP_SELF']) != 'register.php') {
     header("Location: login.php");
     exit();

--- a/login.php
+++ b/login.php
@@ -1,5 +1,7 @@
 <?php
-session_start();
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
 require 'config.php';
 
 $msg = '';
@@ -13,7 +15,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
     $stmt->bind_result($user_id, $hash, $is_admin);
     $stmt->fetch();
 
-    if ($user_id && password_verify($password, $hash)) {
+    if ($user_id && $password === $hash) {
         $_SESSION['user_id'] = $user_id;
         $_SESSION['is_admin'] = $is_admin;
         $target = $is_admin ? 'admin.php' : 'dashboard.php';

--- a/logout.php
+++ b/logout.php
@@ -1,2 +1,8 @@
-<?php session_start(); session_destroy(); header("Location: login.php"); ?>
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+session_destroy();
+header("Location: login.php");
+?>
 

--- a/register.php
+++ b/register.php
@@ -7,7 +7,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
     $phone = $_POST['phone'];
     $email = $_POST['email'];
     $login = $_POST['login'];
-    $password = password_hash($_POST['password'], PASSWORD_DEFAULT);
+    $password = $_POST['password'];
 
     if (mb_strlen($login) < 6 || mb_strlen($_POST['password']) < 6) {
         $msg = "<div class='alert alert-danger'>Логин и пароль должны быть не менее 6 символов.</div>";


### PR DESCRIPTION
## Summary
- simplify registration by storing plaintext passwords
- check `session_status()` before starting sessions
- compare passwords directly on login

## Testing
- `php -l register.php` *(fails: php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68546eef88c88333ac1184973be8d984