### PR TITLE
Fix dashboard PHP output handling

### DIFF
--- a/dashboard.php
+++ b/dashboard.php
@@ -1,19 +1,35 @@
-<?php require 'config.php'; require 'header.php';
+<?php
+require 'config.php';
+require 'header.php';
+
 $user_id = $_SESSION['user_id'];
 
-$result = $mysqli->query("SELECT c.name, c.description, c.image_url, a.id AS app_id, a.start_date, a.payment_method, a.status, r.id AS review_id FROM applications a JOIN courses c ON a.course_id = c.id LEFT JOIN reviews r ON r.application_id = a.id WHERE a.user_id = $user_id");
+$stmt = $mysqli->prepare(
+    "SELECT c.name, c.description, c.image_url, a.id AS app_id, a.start_date, " .
+    "a.payment_method, a.status, r.id AS review_id " .
+    "FROM applications a " .
+    "JOIN courses c ON a.course_id = c.id " .
+    "LEFT JOIN reviews r ON r.application_id = a.id " .
+    "WHERE a.user_id = ?"
+);
+$stmt->bind_param('i', $user_id);
+$stmt->execute();
+$result = $stmt->get_result();
+?>
 
-echo "<h2 class='mb-4'>Ваши заявки</h2><div class='row'>";
-
-while ($row = $result->fetch_assoc()) {
-    echo "<div class='col-md-4 mb-4'>
+<h2 class='mb-4'>Ваши заявки</h2>
+<div class='row'>
+<?php while ($row = $result->fetch_assoc()): ?>
+    <div class='col-md-4 mb-4'>
         <div class='card'>
-            <img src='{$row['image_url']}' class='card-img-top' alt='Курс'>
+            <img src='<?= htmlspecialchars($row['image_url']) ?>' class='card-img-top' alt='Курс'>
             <div class='card-body'>
-                <h5 class='card-title'>{$row['name']}</h5>
-                <p class='card-text'>{$row['description']}</p>
-                <p class='card-text'><small>Дата начала: {$row['start_date']} | Оплата: {$row['payment_method']}</small></p>
-                <span class='badge bg-info'>{$row['status']}</span>
+                <h5 class='card-title'><?= htmlspecialchars($row['name']) ?></h5>
+                <p class='card-text'><?= htmlspecialchars($row['description']) ?></p>
+                <p class='card-text'>
+                    <small>Дата начала: <?= htmlspecialchars($row['start_date']) ?> | Оплата: <?= htmlspecialchars($row['payment_method']) ?></small>
+                </p>
+                <span class='badge bg-info'><?= htmlspecialchars($row['status']) ?></span>
                 <?php if ($row['status'] == 'Обучение завершено'): ?>
                     <?php if ($row['review_id']): ?>
                         <p class='text-success mt-2'>Отзыв оставлен</p>
@@ -23,7 +39,7 @@ while ($row = $result->fetch_assoc()) {
                 <?php endif; ?>
             </div>
         </div>
-    </div>";
-}
-echo "</div>";
-require 'footer.php'; ?>
+    </div>
+<?php endwhile; ?>
+</div>
+<?php require 'footer.php'; ?>


### PR DESCRIPTION
## Summary
- refactor dashboard page to correctly embed PHP and HTML
- use prepared statements and `htmlspecialchars` when rendering course data

## Testing
- `php -l dashboard.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68547cf6237083339a92e639a97e4288

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `dashboard.php` file to enhance security and maintainability by using prepared statements for database queries, improving data output with `htmlspecialchars`, and restructuring the code for better readability.

### Detailed summary
- Added `require 'config.php';` and `require 'header.php';` at the start of the file.
- Replaced direct query execution with a prepared statement using `bind_param`.
- Changed output of database results to use `htmlspecialchars` for better security.
- Reorganized the HTML structure for improved readability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->