### PR TITLE
Add prepare error diagnostics

### DIFF
--- a/dashboard.php
+++ b/dashboard.php
@@ -12,8 +12,13 @@ $stmt = $mysqli->prepare(
     "LEFT JOIN reviews r ON r.application_id = a.id " .
     "WHERE a.user_id = ?"
 );
+if (!$stmt) {
+    die('Query prepare error: ' . htmlspecialchars($mysqli->error));
+}
 $stmt->bind_param('i', $user_id);
-$stmt->execute();
+if (!$stmt->execute()) {
+    die('Query execute error: ' . htmlspecialchars($stmt->error));
+}
 $result = $stmt->get_result();
 ?>
 


### PR DESCRIPTION
## Summary
- add checks for prepare/execute errors in `dashboard.php`

## Testing
- `php -l dashboard.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68547e52d54c8333baf2954404b87772

<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves error handling in the `dashboard.php` file by adding checks for query preparation and execution, ensuring that any issues are reported clearly.

### Detailed summary
- Added an error check after preparing the statement with `if (!$stmt)`.
- Included a descriptive error message for query preparation failure.
- Added an error check after executing the statement with `if (!$stmt->execute())`.
- Included a descriptive error message for query execution failure.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->