### PR TITLE
Fix phone mask formatting

### DIFF
--- a/register.php
+++ b/register.php
@@ -51,9 +51,15 @@ document.addEventListener('DOMContentLoaded', () => {
   if (phone) {
     phone.addEventListener('input', () => {
       let digits = phone.value.replace(/\D/g, '').substring(0, 10);
-      let result = '+7(';
-      if (digits.length >= 1) result += digits.substring(0, 3);
-      if (digits.length >= 4) result += ')-' + digits.substring(3, 6);
+      let result = '+7 (';
+      if (digits.length > 0) {
+        result += digits.substring(0, 3);
+      }
+      if (digits.length >= 4) {
+        result += ') ' + digits.substring(3, 6);
+      } else if (digits.length >= 3) {
+        result += ')';
+      }
       if (digits.length >= 7) result += '-' + digits.substring(6, 8);
       if (digits.length >= 9) result += '-' + digits.substring(8, 10);
       phone.value = result;


### PR DESCRIPTION
## Summary
- fix phone input mask to produce `+7 (xxx) xxx-xx-xx`

## Testing
- `node -e "function mask(val){let digits=val.replace(/\D/g,'').substring(0,10);let result='+7 (';if(digits.length>0)result+=digits.substring(0,3);if(digits.length>=4)result+=') '+digits.substring(3,6);else if(digits.length>=3)result+=')';if(digits.length>=7)result+='-'+digits.substring(6,8);if(digits.length>=9)result+='-'+digits.substring(8,10);return result;} console.log(mask('1234567890'));"`


------
https://chatgpt.com/codex/tasks/task_e_68547ed84c18833389b83dfabbfaf1bc

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the formatting of a phone number input in the `register.php` file. It enhances the user experience by providing clearer separation of the country code and area code.

### Detailed summary
- Changed the initial formatting of `result` from `'+7('` to `'+7 ('`.
- Updated the condition to check for digits: changed `if (digits.length >= 1)` to `if (digits.length > 0)`.
- Added a new condition to add a closing parenthesis if there are at least 3 digits.
- Adjusted the formatting logic for area code and number separation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->